### PR TITLE
Add AssertionDlg modules

### DIFF
--- a/src/assertion_dlg.cpp
+++ b/src/assertion_dlg.cpp
@@ -1,0 +1,86 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Assertion Dialog
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License ( see ../LICENSE )
+/////////////////////////////////////////////////////////////////////////////
+
+#include <cstdlib>
+#include <mutex>
+
+#include <wx/msgdlg.h>
+
+static std::mutex g_mutexAssert;
+
+#if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && defined(__cpp_consteval)
+
+bool AssertionDlg(const std::source_location& location, const char* cond, std::string_view msg)
+{
+    // This is in case additional message processing results in an assert while this one is already being displayed.
+    std::unique_lock<std::mutex> classLock(g_mutexAssert);
+
+    ttlib::cstr str;
+
+    if (cond)
+        str << "Expression: " << cond << "\n\n";
+    if (!msg.empty())
+        str << "Comment: " << msg << "\n\n";
+
+    str << "File: " << location.file_name() << "\n";
+    str << "Function: " << location.function_name() << "\n";
+    str << "Line: " << (size_t) location.line() << "\n";
+
+    wxMessageDialog dlg(nullptr, str.wx_str(), "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
+    dlg.SetYesNoCancelLabels("wxTrap", "Continue", "Exit program");
+
+    auto answer = dlg.ShowModal();
+
+    if (answer == wxID_YES)
+    {
+        return true;
+    }
+    else if (answer == wxID_CANCEL)
+    {
+        std::quick_exit(2);
+    }
+
+    return false;
+}
+
+#else  // not defined(__cpp_consteval)
+
+bool AssertionDlg(const char* filename, const char* function, int line, const char* cond, const std::string& msg)
+{
+    // This is in case additional message processing results in an assert while this one is already being displayed.
+    std::unique_lock<std::mutex> classLock(g_mutexAssert);
+
+    ttlib::cstr str;
+
+    if (cond)
+        str << "Expression: " << cond << "\n\n";
+    if (!msg.empty())
+        str << "Comment: " << msg << "\n\n";
+
+    str << "File: " << filename << "\n";
+    str << "Function: " << function << "\n";
+    str << "Line: " << line << "\n\n";
+    str << "Press Yes to call wxTrap, No to continue, Cancel to exit program.";
+
+    wxMessageDialog dlg(nullptr, str.wx_str(), "Assertion!", wxCENTRE | wxYES_NO | wxCANCEL);
+    dlg.SetYesNoCancelLabels("wxTrap", "Continue", "Exit program");
+
+    auto answer = dlg.ShowModal();
+
+    if (answer == wxID_YES)
+    {
+        return true;
+    }
+    else if (answer == wxID_CANCEL)
+    {
+        std::quick_exit(2);
+    }
+
+    return false;
+}
+
+#endif  // defined(__cpp_consteval)

--- a/src/assertion_dlg.h
+++ b/src/assertion_dlg.h
@@ -1,0 +1,81 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Assertion Dialog
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2022 KeyWorks Software (Ralph Walden)
+// License:   Apache License ( see ../LICENSE )
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <source_location>
+
+// Check for __cpp_consteval because clang 14 supports c++20 but not __cpp_consteval or std::source_location.
+
+#if (__cplusplus >= 202002L || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)) && defined(__cpp_consteval)
+
+// This should *ONLY* be called in the GUI thread (if there is one)!
+//
+// This function is available in Release builds as well as Debug builds.
+bool AssertionDlg(const std::source_location& location, const char* cond, std::string_view msg);
+
+    #if defined(NDEBUG) && !defined(INTERNAL_TESTING)
+        #define ASSERT(cond)
+        #define ASSERT_MSG(cond, msg)
+        #define FAIL_MSG(msg)
+    #else  // not defined(NDEBUG) && !defined(INTERNAL_TESTING)
+        #define ASSERT(cond)                                                  \
+            if (!(cond))                                                      \
+            {                                                                 \
+                if (AssertionDlg(std::source_location::current(), #cond, "")) \
+                {                                                             \
+                    wxTrap();                                                 \
+                }                                                             \
+            }
+
+        #define ASSERT_MSG(cond, msg)                                            \
+            if (!(cond))                                                         \
+            {                                                                    \
+                if (AssertionDlg(std::source_location::current(), #cond, (msg))) \
+                {                                                                \
+                    wxTrap();                                                    \
+                }                                                                \
+            }
+
+        #define FAIL_MSG(msg)                                                       \
+            {                                                                       \
+                if (AssertionDlg(std::source_location::current(), "failed", (msg))) \
+                {                                                                   \
+                    wxTrap();                                                       \
+                }                                                                   \
+            }
+    #endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)
+
+#else
+
+bool AssertionDlg(const char* filename, const char* function, int line, const char* cond, const std::string& msg);
+
+    #if defined(NDEBUG) && !defined(INTERNAL_TESTING)
+        #define ASSERT(cond)
+        #define ASSERT_MSG(cond, msg)
+        #define FAIL_MSG(msg)
+    #else  // not defined(NDEBUG) && !defined(INTERNAL_TESTING)
+        #define ASSERT(cond)                                                      \
+            if (!(cond) && AssertionDlg(__FILE__, __func__, __LINE__, #cond, "")) \
+            {                                                                     \
+                wxTrap();                                                         \
+            }
+
+        #define ASSERT_MSG(cond, msg)                                                \
+            if (!(cond) && AssertionDlg(__FILE__, __func__, __LINE__, #cond, (msg))) \
+            {                                                                        \
+                wxTrap();                                                            \
+            }
+
+        #define FAIL_MSG(msg)                                              \
+            if (AssertionDlg(__FILE__, __func__, __LINE__, "failed", msg)) \
+            {                                                              \
+                wxTrap();                                                  \
+            }
+    #endif  // defined(NDEBUG) && !defined(INTERNAL_TESTING)
+
+#endif


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds `assertion_dlg.h` and `assertion_dlg.cpp` but does _not_ add it to the standard build set, leaving it up to the caller to build it themselves or not. The reason for this is that the source file can be optionally built in Release builds if the caller wants to call `AssertionDlg` directly. It also can be used to replace the ASSERT macros typically used in KeyWorks repositories, and won't always be desirable.

Note that if building with a c++20 compile that supports `__cpp_consteval` (clang 14 supports c++20 but not __cpp_consteval), `std::source_location` is used instead of the older macros (\_\_FILE\_\_, \_\_func\_\_, \_\_LINE\_\_).
