### PR TITLE
Add missing std::string functions to ttString

### DIFF
--- a/src/ttstring_wx.h
+++ b/src/ttstring_wx.h
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // Purpose:   wxString with additional methods similar to ttlib::cstr
 // Author:    Ralph Walden
-// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// Copyright: Copyright (c) 2020-2023 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
@@ -315,6 +315,18 @@ public:
     /// If is_dir is false, current sting is assumed to contain a filename in the path to
     /// change to.
     bool ChangeDir(bool is_dir = true) const;
+
+    // wxString contains several functions that work the same as std::string/wstring functions.
+    // The following functions are additional std::string/wstring functions that are not
+    // part of wxString.
+
+    // Like std::string.back(), return is undefined if string is empty
+    auto back() { return GetChar(size() - 1); }
+
+    // Like std::string.front(), return is undefined if string is empty
+    auto front() { return GetChar(0); }
+
+    void pop_back() { RemoveLast(); }
 };
 
 /// This class saves the current working directory, and changes to that directory when the


### PR DESCRIPTION
This adds back(), front(), and pop_bacl() -- none of which are part of wxString (as of wxWidgets 3.2.1).

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
